### PR TITLE
JET-1307 Configurable key/value MetricGroups for stateful functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <artifactId>statefun-parent</artifactId>
     <groupId>org.apache.flink</groupId>
     <name>statefun-parent</name>
-    <version>3.2.0.1</version>
+    <version>3.2.0.2</version>
     <packaging>pom</packaging>
 
     <url>http://flink.apache.org</url>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -57,7 +57,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.1</version>
+            <version>3.2.0.2</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,7 +46,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.1</version>
+            <version>3.2.0.2</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -107,6 +107,20 @@ public class StatefulFunctionsConfig implements Serializable {
           .withDescription(
               "The name of the remote module entity to look for. Also supported, file:///...");
 
+  public static final ConfigOption<String> METRICS_FUNCTION_NAMESPACE_KEY =
+      ConfigOptions.key("statefun.metrics.function.namespace.key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription(
+              "Enable key/value metrics for functions using the supplied key in the 'namespace' MetricGroup");
+
+  public static final ConfigOption<String> METRICS_FUNCTION_TYPE_KEY =
+      ConfigOptions.key("statefun.metrics.function.type.key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription(
+              "Enable key/value metrics for functions using the supplied key in the 'type' MetricGroup");
+
   /**
    * Creates a new {@link StatefulFunctionsConfig} based on the default configurations in the
    * current environment set via the {@code flink-conf.yaml}.
@@ -136,6 +150,9 @@ public class StatefulFunctionsConfig implements Serializable {
 
   private Map<String, String> globalConfigurations = new HashMap<>();
 
+  private String metricFunctionNamespaceKey;
+  private String metricFunctionTypeKey;
+
   /**
    * Create a new configuration object based on the values set in flink-conf.
    *
@@ -149,6 +166,8 @@ public class StatefulFunctionsConfig implements Serializable {
     this.feedbackBufferSize = configuration.get(TOTAL_MEMORY_USED_FOR_FEEDBACK_CHECKPOINTING);
     this.maxAsyncOperationsPerTask = configuration.get(ASYNC_MAX_OPERATIONS_PER_TASK);
     this.remoteModuleName = configuration.get(REMOTE_MODULE_NAME);
+    this.metricFunctionNamespaceKey = configuration.get(METRICS_FUNCTION_NAMESPACE_KEY);
+    this.metricFunctionTypeKey = configuration.get(METRICS_FUNCTION_TYPE_KEY);
 
     for (String key : configuration.keySet()) {
       if (key.startsWith(MODULE_CONFIG_PREFIX)) {
@@ -232,6 +251,30 @@ public class StatefulFunctionsConfig implements Serializable {
    */
   public void setRemoteModuleName(String remoteModuleName) {
     this.remoteModuleName = Objects.requireNonNull(remoteModuleName);
+  }
+
+  /**
+   * Returns the key name to use for key/value metric groups at the function 'namespace' level of
+   * the metric group hierarchy.
+   */
+  public String getMetricFunctionNamespaceKey() {
+    return metricFunctionNamespaceKey;
+  }
+
+  public void setMetricFunctionNamespaceKey(String metricFunctionNamespaceKey) {
+    this.metricFunctionNamespaceKey = metricFunctionNamespaceKey;
+  }
+
+  /**
+   * Returns the key name to use for key/value metric groups at the function 'type' level of the
+   * metric group hierarchy.
+   */
+  public String getMetricFunctionTypeKey() {
+    return metricFunctionTypeKey;
+  }
+
+  public void setMetricFunctionTypeKey(String metricFunctionTypeKey) {
+    this.metricFunctionTypeKey = metricFunctionTypeKey;
   }
 
   /**

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -141,7 +141,8 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
             MessageFactory.forKey(statefulFunctionsUniverse.messageFactoryKey()),
             new MailboxExecutorFacade(mailboxExecutor, "Stateful Functions Mailbox"),
             getRuntimeContext().getMetricGroup().addGroup("functions"),
-            asyncOperationState);
+            asyncOperationState,
+            configuration);
 
     //
     // expire all the pending async operations.

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.backpressure.BackPressureValve;
 import org.apache.flink.statefun.flink.core.di.Inject;
@@ -68,7 +69,8 @@ final class Reductions {
       MessageFactory messageFactory,
       Executor mailboxExecutor,
       MetricGroup metricGroup,
-      MapState<Long, Message> asyncOperations) {
+      MapState<Long, Message> asyncOperations,
+      StatefulFunctionsConfig configuration) {
 
     ObjectContainer container = new ObjectContainer();
 
@@ -109,7 +111,7 @@ final class Reductions {
     container.add(
         "function-metrics-factory",
         FuncionTypeMetricsFactory.class,
-        new FlinkFuncionTypeMetricsFactory(metricGroup));
+        new FlinkFuncionTypeMetricsFactory(metricGroup, configuration));
     container.add(
         "function-dispatcher-metrics",
         FunctionDispatcherMetrics.class,

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
@@ -19,21 +19,32 @@ package org.apache.flink.statefun.flink.core.metrics;
 
 import java.util.Objects;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.metrics.Metrics;
 
 public class FlinkFuncionTypeMetricsFactory implements FuncionTypeMetricsFactory {
 
   private final MetricGroup metricGroup;
+  private final StatefulFunctionsConfig configuration;
 
-  public FlinkFuncionTypeMetricsFactory(MetricGroup metricGroup) {
+  public FlinkFuncionTypeMetricsFactory(
+      MetricGroup metricGroup, StatefulFunctionsConfig configuration) {
     this.metricGroup = Objects.requireNonNull(metricGroup);
+    this.configuration = Objects.requireNonNull(configuration);
   }
 
   @Override
   public FunctionTypeMetrics forType(FunctionType functionType) {
-    MetricGroup namespace = metricGroup.addGroup(functionType.namespace());
-    MetricGroup typeGroup = namespace.addGroup(functionType.name());
+    MetricGroup namespace =
+        (configuration.getMetricFunctionNamespaceKey() != null)
+            ? metricGroup.addGroup(
+                configuration.getMetricFunctionNamespaceKey(), functionType.namespace())
+            : metricGroup.addGroup(functionType.namespace());
+    MetricGroup typeGroup =
+        (configuration.getMetricFunctionTypeKey() != null)
+            ? namespace.addGroup(configuration.getMetricFunctionTypeKey(), functionType.name())
+            : namespace.addGroup(functionType.name());
     Metrics functionTypeScopedMetrics = new FlinkUserMetrics(typeGroup);
     return new FlinkFunctionTypeMetrics(typeGroup, functionTypeScopedMetrics);
   }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -55,6 +55,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -72,6 +73,7 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.statefun.flink.core.backpressure.ThresholdBackPressureValve;
@@ -108,7 +110,8 @@ public class ReductionsTest {
             TestUtils.ENVELOPE_FACTORY,
             MoreExecutors.directExecutor(),
             new FakeMetricGroup(),
-            new FakeMapState<>());
+            new FakeMapState<>(),
+            StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration()));
 
     assertThat(reductions, notNullValue());
   }

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-go/pom.xml
+++ b/statefun-sdk-go/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-go</artifactId>

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-js/pom.xml
+++ b/statefun-sdk-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-python/pom.xml
+++ b/statefun-sdk-python/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.1</version>
+        <version>3.2.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This change provides new configuration options to control metric names and variables for the metrics created by stateful functions.  Specifically, this change allows switching between metric names where the function namespace and type appear in the metric name, and where the function namespace and type appear as metric variables (aka prometheus labels).

Consider a function with `namespace="my_ns"` and `type="my_func"` which increments a counter named "ignored".

```
context.metrics().counter("ignored").inc();
```

Traditionally, and by default if the new configuration values provided by this PR are not set, the counter metric name will have the function namespace and type embedded into the metric name like this: `flink_taskmanager_job_task_operator_functions_my_ns_my_func_ignored`.

With this PR, a stateful function job may set the new configuration values as follows in `flink-conf.yaml`:

```
statefun.metrics.function.namespace.key: ns
statefun.metrics.function.type.key: type
```

The metric name in this case will be `flink_taskmanager_job_task_operator_functions_ns_type_ignored` and will have variables (aka prometheus labels) of `ns="my_ns", type="my_func"`.

We can then write simple queries for Grafana to display metrics common to multiple functions in a single panel.  Using `inRate` as an example, the following Prometheus query will produce results to show the rate of invocation for all functions in the job.

```
sum by (ns,type) (sum(flink_taskmanager_job_task_operator_functions_ns_type_inRate))
```