### PR TITLE
Fix failing builds on ARM/Apple-Mx via version upgrades on protoc/protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@ under the License.
         <java.version>1.8</java.version>
         <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
         <auto-service.version>1.0-rc6</auto-service.version>
-        <protobuf.version>3.7.1</protobuf.version>
+        <protobuf.version>3.25.6</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
-        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
         <flink.version>1.14.3</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.7</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <artifactId>statefun-parent</artifactId>
     <groupId>org.apache.flink</groupId>
     <name>statefun-parent</name>
-    <version>3.2.0.2</version>
+    <version>3.2.0.3</version>
     <packaging>pom</packaging>
 
     <url>http://flink.apache.org</url>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -57,7 +57,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.2</version>
+            <version>3.2.0.3</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,7 +46,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.2</version>
+            <version>3.2.0.3</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-go/pom.xml
+++ b/statefun-sdk-go/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-go</artifactId>

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-js/pom.xml
+++ b/statefun-sdk-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-python/pom.xml
+++ b/statefun-sdk-python/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -32,7 +32,6 @@ under the License.
 
     <properties>
         <protobuf-sources.dir>${generated-sources.basedir}/shaded-protobuf-java/</protobuf-sources.dir>
-        <protobuf.version>3.7.1</protobuf.version>
     </properties>
 
     <dependencies>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Builds on Apple silicon were failing, this PR fixes the issue by upgrading to a newer protobuf version

Tested via
- local install of this library
- updated rad-fastlane-statefun to use the new version
- ran in local pipeline without issue.