### PR TITLE
JET-2087: metric group adapter factory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@ under the License.
         <java.version>1.8</java.version>
         <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
         <auto-service.version>1.0-rc6</auto-service.version>
-        <protobuf.version>3.7.1</protobuf.version>
+        <protobuf.version>3.25.6</protobuf.version>
         <unixsocket.version>2.3.2</unixsocket.version>
-        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
         <flink.version>1.14.3</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.7</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <artifactId>statefun-parent</artifactId>
     <groupId>org.apache.flink</groupId>
     <name>statefun-parent</name>
-    <version>3.2.0.2</version>
+    <version>3.2.0.3</version>
     <packaging>pom</packaging>
 
     <url>http://flink.apache.org</url>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -57,7 +57,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.2</version>
+            <version>3.2.0.3</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,7 +46,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.2.0.2</version>
+            <version>3.2.0.3</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfig.java
@@ -153,6 +153,8 @@ public class StatefulFunctionsConfig implements Serializable {
   private String metricFunctionNamespaceKey;
   private String metricFunctionTypeKey;
 
+  private String metricGroupAdapterFactoryClassName;
+
   /**
    * Create a new configuration object based on the values set in flink-conf.
    *
@@ -275,6 +277,14 @@ public class StatefulFunctionsConfig implements Serializable {
 
   public void setMetricFunctionTypeKey(String metricFunctionTypeKey) {
     this.metricFunctionTypeKey = metricFunctionTypeKey;
+  }
+
+  public String getMetricGroupAdapterFactoryClassName() {
+    return metricGroupAdapterFactoryClassName;
+  }
+
+  public void setMetricGroupAdapterFactoryClassName(String metricGroupAdapterFactoryClassName) {
+    this.metricGroupAdapterFactoryClassName = metricGroupAdapterFactoryClassName;
   }
 
   /**

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackSinkOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/feedback/FeedbackSinkOperator.java
@@ -19,9 +19,9 @@ package org.apache.flink.statefun.flink.core.feedback;
 
 import java.util.Objects;
 import java.util.function.LongFunction;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -41,7 +41,7 @@ public final class FeedbackSinkOperator<V> extends AbstractStreamOperator<Void>
   // ----- runtime -----
 
   private transient FeedbackChannel<V> channel;
-  private transient SimpleCounter totalProduced;
+  private transient Counter totalProduced;
 
   public FeedbackSinkOperator(FeedbackKey<V> key, LongFunction<V> barrierSentinelSupplier) {
     this.key = Objects.requireNonNull(key);
@@ -75,7 +75,7 @@ public final class FeedbackSinkOperator<V> extends AbstractStreamOperator<Void>
 
     // metrics
     MetricGroup metrics = getRuntimeContext().getMetricGroup();
-    SimpleCounter produced = metrics.counter("produced", new SimpleCounter());
+    Counter produced = metrics.counter("produced");
     metrics.meter("producedRate", new MeterView(produced, 60));
     this.totalProduced = produced;
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/functions/Reductions.java
@@ -38,6 +38,7 @@ import org.apache.flink.statefun.flink.core.metrics.FlinkFunctionDispatcherMetri
 import org.apache.flink.statefun.flink.core.metrics.FuncionTypeMetricsFactory;
 import org.apache.flink.statefun.flink.core.metrics.FunctionDispatcherMetrics;
 import org.apache.flink.statefun.flink.core.metrics.FunctionTypeMetricsRepository;
+import org.apache.flink.statefun.flink.core.metrics.MetricGroupAdapterFactoryUtil;
 import org.apache.flink.statefun.flink.core.state.FlinkState;
 import org.apache.flink.statefun.flink.core.state.State;
 import org.apache.flink.statefun.flink.core.types.DynamicallyRegisteredTypes;
@@ -115,7 +116,9 @@ final class Reductions {
     container.add(
         "function-dispatcher-metrics",
         FunctionDispatcherMetrics.class,
-        new FlinkFunctionDispatcherMetrics(metricGroup));
+        new FlinkFunctionDispatcherMetrics(
+            MetricGroupAdapterFactoryUtil.getMetricGroupAdapterFactory(configuration)
+                .createMetricGroupAdapter(metricGroup)));
 
     // for delayed messages
     container.add(

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFuncionTypeMetricsFactory.java
@@ -45,7 +45,10 @@ public class FlinkFuncionTypeMetricsFactory implements FuncionTypeMetricsFactory
         (configuration.getMetricFunctionTypeKey() != null)
             ? namespace.addGroup(configuration.getMetricFunctionTypeKey(), functionType.name())
             : namespace.addGroup(functionType.name());
-    Metrics functionTypeScopedMetrics = new FlinkUserMetrics(typeGroup);
-    return new FlinkFunctionTypeMetrics(typeGroup, functionTypeScopedMetrics);
+    MetricGroup adapterGroup =
+        MetricGroupAdapterFactoryUtil.getMetricGroupAdapterFactory(configuration)
+            .createMetricGroupAdapter(typeGroup);
+    Metrics functionTypeScopedMetrics = new FlinkUserMetrics(adapterGroup);
+    return new FlinkFunctionTypeMetrics(adapterGroup, functionTypeScopedMetrics);
   }
 }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetrics.java
@@ -24,7 +24,6 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.statefun.sdk.metrics.Metrics;
 
 final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
@@ -117,8 +116,8 @@ final class FlinkFunctionTypeMetrics implements FunctionTypeMetrics {
     remoteInvocationLatency.update(elapsed);
   }
 
-  private static SimpleCounter metered(MetricGroup metrics, String name) {
-    SimpleCounter counter = metrics.counter(name, new SimpleCounter());
+  private static Counter metered(MetricGroup metrics, String name) {
+    Counter counter = metrics.counter(name);
     metrics.meter(name + "Rate", new MeterView(counter, 60));
     return counter;
   }

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkUserMetrics.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/FlinkUserMetrics.java
@@ -23,7 +23,6 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashMap;
 import java.util.Objects;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.statefun.sdk.metrics.Counter;
 import org.apache.flink.statefun.sdk.metrics.Metrics;
 
@@ -41,7 +40,7 @@ public final class FlinkUserMetrics implements Metrics {
     Objects.requireNonNull(name);
     Counter counter = counters.get(name);
     if (counter == null) {
-      SimpleCounter internalCounter = typeGroup.counter(name, new SimpleCounter());
+      org.apache.flink.metrics.Counter internalCounter = typeGroup.counter(name);
       counters.put(name, counter = wrapFlinkCounterAsSdkCounter(internalCounter));
     }
     return counter;

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/MetricGroupAdapterFactory.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/MetricGroupAdapterFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Factory interface for MetricGroup adapters. The use of this interface allows the returned
+ * MetricGroup to be an adapter/wrapper around the input/adapted group.
+ */
+public interface MetricGroupAdapterFactory {
+  MetricGroup createMetricGroupAdapter(MetricGroup adapted);
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/MetricGroupAdapterFactoryUtil.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/metrics/MetricGroupAdapterFactoryUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.statefun.flink.core.metrics;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class for obtaining the MetricGroupAdapterFactory. */
+public class MetricGroupAdapterFactoryUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetricGroupAdapterFactoryUtil.class);
+
+  private static MetricGroupAdapterFactory factory = null;
+
+  public static MetricGroupAdapterFactory getMetricGroupAdapterFactory(
+      StatefulFunctionsConfig config) {
+
+    if (factory != null) {
+      return factory;
+    }
+
+    if (StringUtils.isNotEmpty(config.getMetricGroupAdapterFactoryClassName())) {
+      try {
+        Class<?> clazz = Class.forName(config.getMetricGroupAdapterFactoryClassName());
+        if (MetricGroupAdapterFactory.class.isAssignableFrom(clazz)) {
+          factory = (MetricGroupAdapterFactory) clazz.getDeclaredConstructor().newInstance();
+          return factory;
+        } else {
+          LOG.warn(
+              "Class {} is not a MetricGroupAdapterFactory.",
+              config.getMetricGroupAdapterFactoryClassName());
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "Failed to create MetricGroupAdapterFactory from class: {}.",
+            config.getMetricGroupAdapterFactoryClassName(),
+            e);
+      }
+    }
+    LOG.info("Using default MetricGroupAdapterFactory.");
+    factory = adapted -> adapted;
+    return factory;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/IngressRouterOperator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/translation/IngressRouterOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.statefun.flink.core.message.Message;
 import org.apache.flink.statefun.flink.core.message.MessageFactory;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
 import org.apache.flink.statefun.flink.core.metrics.FlinkUserMetrics;
+import org.apache.flink.statefun.flink.core.metrics.MetricGroupAdapterFactoryUtil;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.Router;
@@ -73,7 +74,10 @@ public final class IngressRouterOperator<T> extends AbstractStreamOperator<Messa
 
     MetricGroup routersMetricGroup =
         getMetricGroup().addGroup("routers").addGroup(id.namespace()).addGroup(id.name());
-    Metrics routersMetrics = new FlinkUserMetrics(routersMetricGroup);
+    MetricGroup adapterGroup =
+        MetricGroupAdapterFactoryUtil.getMetricGroupAdapterFactory(configuration)
+            .createMetricGroupAdapter(routersMetricGroup);
+    Metrics routersMetrics = new FlinkUserMetrics(adapterGroup);
 
     this.routers = loadRoutersAttachedToIngress(id, universe.routers());
     this.downstream =

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-go/pom.xml
+++ b/statefun-sdk-go/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-go</artifactId>

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-js/pom.xml
+++ b/statefun-sdk-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-python/pom.xml
+++ b/statefun-sdk-python/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -32,7 +32,6 @@ under the License.
 
     <properties>
         <protobuf-sources.dir>${generated-sources.basedir}/shaded-protobuf-java/</protobuf-sources.dir>
-        <protobuf.version>3.7.1</protobuf.version>
     </properties>
 
     <dependencies>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>3.2.0.2</version>
+        <version>3.2.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
These changes allow a factory class for metric group adapters to be configured.  When configured, the factory class is used to create an adapter around metric groups managed by the Stateful Functions SDK, allowing the Counter type to be controlled in the adapter implementation.  Our own stateful functions application can then configure a factory, and from the adapter return counters that implement the Flink `Counter` contract while also reporting their values out via OpenTelemetry Protocol.  AWS Managed Flink provides no way to configure metic reporters, and so this is the way I think we should be doing it if we want metrics to go out via OpenTelemetry.

I changed several calls from `metricGroup.counter(name, new SimpleCounter())` to `metricGroup.counter(name)` because a) `metricGroup.counter(name)` just creates a SimpleCounter() anyway and returns a `Counter`, and b)  `metricGroup.counter(name, new SimpleCounter())` is defined in Flink's MetricGroup interface as `<C extends Counter> C counter(String name, C counter);` making it impossible for the adapter's implementation of that method to return anything other than the counter passed in the second parameter.

The protobuf/protoc version changes in the pom files allow this library to build on Apple silicon.